### PR TITLE
Miscellaneous Fixes & Tweaks (#1504)

### DIFF
--- a/code/__defines/species_languages.dm
+++ b/code/__defines/species_languages.dm
@@ -24,8 +24,10 @@
 #define HAS_SOCKS         0x40   // If this species can wear socks
 #define HAS_FBP           0x80   // If for whatever ungodly reason we decide to ever have non-Shell FBPs.
 
-// Languages.
-#define LANGUAGE_EAL "Encoded Audio Language"
+// Tau-Ceti basic, language common to all crew.
+#define LANGUAGE_TCB "Ceti Basic"
+
+// Species languages
 #define LANGUAGE_SOL_COMMON "Sol Common"
 #define LANGUAGE_UNATHI "Sinta'unathi"
 #define LANGUAGE_SIIK_MAAS "Siik'maas"
@@ -38,6 +40,29 @@
 #define LANGUAGE_GUTTER "Gutter"
 #define LANGUAGE_VAURCA "Hivenet"
 #define LANGUAGE_AZAZIBA "Sinta'azaziba"
+#define LANGUAGE_SIGN "Sign Language"
+
+// Antag Languages
+#define LANGUAGE_XENOMORPH "Xenomorph"
+#define LANGUAGE_HIVEMIND "Hivemind"	// xeno hivemind
+#define LANGUAGE_VOX "Vox-pidgin"
+#define LANGUAGE_CHANGELING "Changeling"
+#define LANGUAGE_BORER "Cortical Link"
+#define LANGUAGE_CULT "Cult"		// NOT CULTISTS!
+#define LANGUAGE_OCCULT "Occult"
+#define LANGUAGE_TERMINATOR "Hephaestus Darkcomms"	// HKs.
+
+// Lesser-form Languages
+#define LANGUAGE_CHIMPANZEE "Chimpanzee"	// human
+#define LANGUAGE_NEAERA "Neaera"			// skrell
+#define LANGUAGE_STOK "Stok"				// unathi
+#define LANGUAGE_FARWA "Farwa"				// tajara
+#define LANGUAGE_BUG "V'krexi"				// vaurca
+
+// Synth Languages
+#define LANGUAGE_ROBOT "Robot Talk"
+#define LANGUAGE_DRONE "Drone Talk"
+#define LANGUAGE_EAL "Encoded Audio Language"
 
 // Language flags.
 #define WHITELISTED  1   // Language is available if the speaker is whitelisted.

--- a/code/modules/admin/verbs/bluespacetech.dm
+++ b/code/modules/admin/verbs/bluespacetech.dm
@@ -24,7 +24,7 @@
 		return
 
 	if(ticker.current_state < GAME_STATE_PLAYING)
-		src << "\red The game hasn't started yet!"
+		src << span("alert", "The game hasn't started yet!")
 		return
 
 	if(istype(mob, /mob/living))
@@ -85,22 +85,34 @@
 
 	//Add the rest of the languages
 	//Because universal speak doesn't work right.
+
+	bst.add_language(LANGUAGE_TCB)
+	bst.add_language(LANGUAGE_GUTTER)
+	bst.add_language(LANGUAGE_SIGN)
+	bst.add_language(LANGUAGE_TRADEBAND)
+	// Unathi languages
 	bst.add_language(LANGUAGE_UNATHI)
+	bst.add_language(LANGUAGE_AZAZIBA)
+	// Tajara languages
 	bst.add_language(LANGUAGE_SIIK_MAAS)
+	bst.add_language(LANGUAGE_SIIK_TAJR)
+	bst.add_language(LANGUAGE_SIGN_TAJARA)
+	// Other station species' languages
 	bst.add_language(LANGUAGE_SKRELLIAN)
-	bst.add_language("Vox-pidgin")
-	bst.add_language("Rootsong")
-	bst.add_language("Ceti Basic")
-	bst.add_language("Sol Common")
-	bst.add_language("Tradeband")
-	bst.add_language("Gutter")
-	bst.add_language("Sign Language")
-	bst.add_language("Xenomorph")
-	bst.add_language("Hivemind")
-	bst.add_language("Changeling")
-	bst.add_language("Cortical Link")
-	bst.add_language("Robot Talk")
-	bst.add_language("Drone Talk")
+	bst.add_language(LANGUAGE_SOL_COMMON)
+	bst.add_language(LANGUAGE_ROOTSONG)
+	bst.add_language(LANGUAGE_VAURCA)
+	bst.add_language(LANGUAGE_RESOMI)	// why not?
+	// Synthetics
+	bst.add_language(LANGUAGE_ROBOT)
+	bst.add_language(LANGUAGE_DRONE)
+	bst.add_language(LANGUAGE_EAL)
+	// Antagonist languages
+	bst.add_language(LANGUAGE_VOX)
+	bst.add_language(LANGUAGE_XENOMORPH)
+	bst.add_language(LANGUAGE_HIVEMIND)
+	bst.add_language(LANGUAGE_CHANGELING)
+	bst.add_language(LANGUAGE_BORER)
 
 	spawn(5)
 		s.start()
@@ -116,214 +128,214 @@
 	universal_understand = 1
 	status_flags = GODMODE
 
-	can_inject(var/mob/user, var/error_msg, var/target_zone)
-		user << "<span class='alert'>The [src] disarms you before you can inject them.</span>"
-		user.drop_item()
-		return 0
+/mob/living/carbon/human/bst/can_inject(var/mob/user, var/error_msg, var/target_zone)
+	user << span("alert", "The [src] disarms you before you can inject them.")
+	user.drop_item()
+	return 0
 
-	binarycheck()
-		return 1
+/mob/living/carbon/human/bst/binarycheck()
+	return 1
 
-	proc/suicide()
-		if(key && species.name != "Human")
-			switch(species.name)
-				if("Tajara")
-					bsc()
-				if("Baseline Frame")
-					bsb()
-				if("Diona")
-					bsd()
-				if("Unathi")
-					bsu()
-				if("Skrell")
-					bss()
-				if("Vaurca")
-					bsv()
+/mob/living/carbon/human/bst/proc/suicide()
+	if(key && species.name != "Human")
+		switch(species.name)
+			if("Tajara")
+				bsc()
+			if("Baseline Frame")
+				bsb()
+			if("Diona")
+				bsd()
+			if("Unathi")
+				bsu()
+			if("Skrell")
+				bss()
+			if("Vaurca")
+				bsv()
+		return
+
+	src.custom_emote(1,"presses a button on their suit, followed by a polite bow.")
+	spawn(10)
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(5, 1, src)
+		s.start()
+		spawn(5)
+			qdel(s)
+		if(key)
+			if(client.holder && client.holder.original_mob)
+				client.holder.original_mob.key = key
+			else
+				var/mob/dead/observer/ghost = new(src)	//Transfer safety to observer spawning proc.
+				ghost.key = key
+				ghost.mind.name = "[ghost.key] BSTech"
+				ghost.name = "[ghost.key] BSTech"
+				ghost.real_name = "[ghost.key] BSTech"
+				ghost.voice_name = "[ghost.key] BSTech"
+		qdel(src)
+	return
+
+/mob/living/carbon/human/bst/proc/bsc() //because we all have our unrealistic snowflakes right?
+	if(set_species("Tajara"))
+		h_style = "Tajaran Ears"
+		name = "Bluespace Cat"
+		voice_name = "Bluespace Cat"
+		real_name = "Bluespace Cat"
+		mind.name = "Bluespace Cat"
+		if(wear_id)
+			var/obj/item/weapon/card/id/id = wear_id
+			if(istype(wear_id, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = wear_id
+				id = pda.id
+			id.registered_name = "Bluespace Cat"
+		gender = "female"
+		regenerate_icons()
+	else
+		ghostize(0)
+		key = null
+		suicide()
+
+/mob/living/carbon/human/bst/proc/bsb()
+	if(set_species("Baseline Frame"))
+		h_style = "blue IPC screen"
+		name = "Bluespace Bot"
+		voice_name = "Bluespace Bot"
+		real_name = "Bluespace Bot"
+		mind.name = "Bluespace Bot"
+		if(wear_id)
+			var/obj/item/weapon/card/id/id = wear_id
+			if(istype(wear_id, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = wear_id
+				id = pda.id
+			id.registered_name = "Bluespace Bot"
+		regenerate_icons()
+	else
+		ghostize(0)
+		key = null
+		suicide()
+
+/mob/living/carbon/human/bst/proc/bsd()
+	if(set_species("Diona"))
+		name = "Bluespace Tree"
+		voice_name = "Bluespace Tree"
+		real_name = "Bluespace Tree"
+		mind.name = "Bluespace Tree"
+		if(wear_id)
+			var/obj/item/weapon/card/id/id = wear_id
+			if(istype(wear_id, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = wear_id
+				id = pda.id
+			id.registered_name = "Bluespace Tree"
+		regenerate_icons()
+	else
+		ghostize(0)
+		key = null
+		suicide()
+
+/mob/living/carbon/human/bst/proc/bsu()
+	if(set_species("Unathi"))
+		h_style = "Unathi Horns"
+		name = "Bluespace Lizard"
+		voice_name = "Bluespace Lizard"
+		real_name = "Bluespace Lizard"
+		mind.name = "Bluespace Lizard"
+		if(wear_id)
+			var/obj/item/weapon/card/id/id = wear_id
+			if(istype(wear_id, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = wear_id
+				id = pda.id
+			id.registered_name = "Bluespace Lizard"
+		regenerate_icons()
+	else
+		ghostize(0)
+		key = null
+		suicide()
+
+/mob/living/carbon/human/bst/proc/bss()
+	if(set_species("Skrell"))
+		h_style = "Skrell Male Tentacles"
+		name = "Bluespace Squid"
+		voice_name = "Bluespace Squid"
+		real_name = "Bluespace Squid"
+		mind.name = "Bluespace Squid"
+		if(wear_id)
+			var/obj/item/weapon/card/id/id = wear_id
+			if(istype(wear_id, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = wear_id
+				id = pda.id
+			id.registered_name = "Bluespace Squid"
+		gender = "female"
+		regenerate_icons()
+	else
+		ghostize(0)
+		key = null
+		suicide()
+
+/mob/living/carbon/human/bst/proc/bsv()
+	if(set_species("Vaurca Worker"))
+		h_style = "Bald"
+		name = "Bluespace Bug"
+		voice_name = "Bluespace Bug"
+		real_name = "Bluespace Bug"
+		mind.name = "Bluespace Bug"
+		if(wear_id)
+			var/obj/item/weapon/card/id/id = wear_id
+			if(istype(wear_id, /obj/item/device/pda))
+				var/obj/item/device/pda/pda = wear_id
+				id = pda.id
+			id.registered_name = "Bluespace Bug"
+		regenerate_icons()
+	else
+		ghostize(0)
+		key = null
+		suicide()
+
+/mob/living/carbon/human/bst/say(var/message)
+	var/verb = "says in a subdued tone"
+	..(message, verb)
+
+/mob/living/carbon/human/bst/verb/bstwalk()
+	set name = "Ruin Everything"
+	set desc = "Uses bluespace technology to phase through solid matter and move quickly."
+	set category = "BST"
+	set popup_menu = 0
+
+	if(!src.incorporeal_move)
+		src.incorporeal_move = 2
+		src << span("notice", "You will now phase through solid matter.")
+	else
+		src.incorporeal_move = 0
+		src << span("notice", "You will no-longer phase through solid matter.")
+	return
+
+/mob/living/carbon/human/bst/verb/bstrecover()
+	set name = "Rejuv"
+	set desc = "Use the bluespace within you to restore your health"
+	set category = "BST"
+	set popup_menu = 0
+
+	src.revive()
+
+/mob/living/carbon/human/bst/verb/bstawake()
+	set name = "Wake up"
+	set desc = "This is a quick fix to the relogging sleep bug"
+	set category = "BST"
+	set popup_menu = 0
+
+	src.sleeping = 0
+
+/mob/living/carbon/human/bst/verb/bstquit()
+	set name = "Teleport out"
+	set desc = "Activate bluespace to leave and return to your original mob (if you have one)."
+	set category = "BST"
+
+	var/client/C = src.client
+	if(C.holder && C.holder.original_mob)
+		if(C.holder.original_mob.key)//Thanks for kicking Tish off the Server Meow, wouldn't have spotted this otherwise.
+			//suicide()
 			return
 
-		src.custom_emote(1,"presses a button on their suit, followed by a polite bow.")
-		spawn(10)
-			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-			s.set_up(5, 1, src)
-			s.start()
-			spawn(5)
-				qdel(s)
-			if(key)
-				if(client.holder && client.holder.original_mob)
-					client.holder.original_mob.key = key
-				else
-					var/mob/dead/observer/ghost = new(src)	//Transfer safety to observer spawning proc.
-					ghost.key = key
-					ghost.mind.name = "[ghost.key] BSTech"
-					ghost.name = "[ghost.key] BSTech"
-					ghost.real_name = "[ghost.key] BSTech"
-					ghost.voice_name = "[ghost.key] BSTech"
-			qdel(src)
-		return
-
-	proc/bsc() //because we all have our unrealistic snowflakes right?
-		if(set_species("Tajara"))
-			h_style = "Tajaran Ears"
-			name = "Bluespace Cat"
-			voice_name = "Bluespace Cat"
-			real_name = "Bluespace Cat"
-			mind.name = "Bluespace Cat"
-			if(wear_id)
-				var/obj/item/weapon/card/id/id = wear_id
-				if(istype(wear_id, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = wear_id
-					id = pda.id
-				id.registered_name = "Bluespace Cat"
-			gender = "female"
-			regenerate_icons()
-		else
-			ghostize(0)
-			key = null
-			suicide()
-
-	proc/bsb()
-		if(set_species("Baseline Frame"))
-			h_style = "blue IPC screen"
-			name = "Bluespace Bot"
-			voice_name = "Bluespace Bot"
-			real_name = "Bluespace Bot"
-			mind.name = "Bluespace Bot"
-			if(wear_id)
-				var/obj/item/weapon/card/id/id = wear_id
-				if(istype(wear_id, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = wear_id
-					id = pda.id
-				id.registered_name = "Bluespace Bot"
-			regenerate_icons()
-		else
-			ghostize(0)
-			key = null
-			suicide()
-
-	proc/bsd()
-		if(set_species("Diona"))
-			name = "Bluespace Tree"
-			voice_name = "Bluespace Tree"
-			real_name = "Bluespace Tree"
-			mind.name = "Bluespace Tree"
-			if(wear_id)
-				var/obj/item/weapon/card/id/id = wear_id
-				if(istype(wear_id, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = wear_id
-					id = pda.id
-				id.registered_name = "Bluespace Tree"
-			regenerate_icons()
-		else
-			ghostize(0)
-			key = null
-			suicide()
-
-	proc/bsu()
-		if(set_species("Unathi"))
-			h_style = "Unathi Horns"
-			name = "Bluespace Lizard"
-			voice_name = "Bluespace Lizard"
-			real_name = "Bluespace Lizard"
-			mind.name = "Bluespace Lizard"
-			if(wear_id)
-				var/obj/item/weapon/card/id/id = wear_id
-				if(istype(wear_id, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = wear_id
-					id = pda.id
-				id.registered_name = "Bluespace Lizard"
-			regenerate_icons()
-		else
-			ghostize(0)
-			key = null
-			suicide()
-
-	proc/bss()
-		if(set_species("Skrell"))
-			h_style = "Skrell Male Tentacles"
-			name = "Bluespace Squid"
-			voice_name = "Bluespace Squid"
-			real_name = "Bluespace Squid"
-			mind.name = "Bluespace Squid"
-			if(wear_id)
-				var/obj/item/weapon/card/id/id = wear_id
-				if(istype(wear_id, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = wear_id
-					id = pda.id
-				id.registered_name = "Bluespace Squid"
-			gender = "female"
-			regenerate_icons()
-		else
-			ghostize(0)
-			key = null
-			suicide()
-
-	proc/bsv()
-		if(set_species("Vaurca Worker"))
-			h_style = "Bald"
-			name = "Bluespace Bug"
-			voice_name = "Bluespace Bug"
-			real_name = "Bluespace Bug"
-			mind.name = "Bluespace Bug"
-			if(wear_id)
-				var/obj/item/weapon/card/id/id = wear_id
-				if(istype(wear_id, /obj/item/device/pda))
-					var/obj/item/device/pda/pda = wear_id
-					id = pda.id
-				id.registered_name = "Bluespace Bug"
-			regenerate_icons()
-		else
-			ghostize(0)
-			key = null
-			suicide()
-
-	say(var/message)
-		var/verb = "says in a subdued tone"
-		..(message, verb)
-
-	verb/bstwalk()
-		set name = "Ruin Everything"
-		set desc = "Uses bluespace technology to phase through solid matter and also move fast."
-		set category = "BST"
-		set popup_menu = 0
-
-		if(!src.incorporeal_move)
-			src.incorporeal_move = 2
-			src << "\blue You will now phase through solid matter."
-		else
-			src.incorporeal_move = 0
-			src << "\blue You will no-longer phase through solid matter."
-		return
-
-	verb/bstrecover()
-		set name = "Rejuv"
-		set desc = "Use the bluespace within you to restore your health"
-		set category = "BST"
-		set popup_menu = 0
-
-		src.revive()
-
-	verb/bstawake()
-		set name = "Wake up"
-		set desc = "This is a quick fix to the reloging sleep bug"
-		set category = "BST"
-		set popup_menu = 0
-
-		src.sleeping = 0
-
-	verb/bstquit()
-		set name = "Teleport out"
-		set desc = "Activate bluespace to leave (and return to your original mob(if you have one))"
-		set category = "BST"
-
-		var/client/C = src.client
-		if(C.holder && C.holder.original_mob)
-			if(C.holder.original_mob.key)//Thanks for kicking Tish off the Server Meow, wouldn't have spotted this otherwise.
-				//suicide()
-				return
-
-			C.holder.original_mob.key = key
-			C.holder.original_mob = null
-		suicide()
+		C.holder.original_mob.key = key
+		C.holder.original_mob = null
+	suicide()
 
 //Equipment. All should have canremove set to 0
 //All items with a /bst need the attack_hand() proc overrided to stop people getting overpowered items.
@@ -334,38 +346,45 @@
 	storage_slots = 56
 	max_w_class = 400
 
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the [src]. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/device/radio/headset/ert/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
 
 //Headset
 /obj/item/device/radio/headset/ert/bst
-	name = "Bluespace Technician's headset"
-	desc = "Bluespace Technician's headset, 'BST' marked on the side."
+	name = "\improper Bluespace Technician's headset"
+	desc = "A Bluespace Technician's headset. The letters 'BST' are stamped on the side."
 	translate_binary = 1
 	translate_hive = 1
 	canremove = 0
 	keyslot1 = new /obj/item/device/encryptionkey/binary
 	keyslot2 = new /obj/item/device/encryptionkey/ert
 
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the [src]. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/device/radio/headset/ert/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
+
+// overload this so we can force translate flags without the required keys
+/obj/item/device/radio/headset/ert/bst/recalculateChannels(var/setDescription = 0)
+	..(setDescription)
+	translate_binary = 1
+	translate_hive = 1
+	translate_hivenet = 1
 
 //Clothes
 /obj/item/clothing/under/rank/centcom_officer/bst
-	name = "Bluespace Technician's Uniform"
-	desc = "Bluespace Technician's Uniform, there is a logo on the sleve, it reads 'BST'."
+	name = "\improper Bluespace Technician's Uniform"
+	desc = "A Bluespace Technician's Uniform. There is a logo on the sleeve that reads 'BST'."
 	has_sensor = 0
 	sensor_mode = 0
 	canremove = 0
@@ -373,36 +392,36 @@
 	cold_protection = FULL_BODY
 	heat_protection = FULL_BODY
 
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the [src]. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/clothing/under/rank/centcom_officer/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
 
 //Gloves
 /obj/item/clothing/gloves/swat/bst
-	name = "Bluespace Technician's gloves"
-	desc = "A pair of modified gloves, 'BST' marked on the side."
+	name = "\improper Bluespace Technician's gloves"
+	desc = "A pair of modified gloves. The letters 'BST' are stamped on the side."
 	siemens_coefficient = 0
 	permeability_coefficient = 0
 	canremove = 0
 
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the [src]. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/clothing/gloves/swat/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
 
 //Sunglasses
 /obj/item/clothing/glasses/sunglasses/bst
-	name = "Bluespace Technician's Glasses"
-	desc = "A pair of sunglasses, these look modified, 'BST' marked on the side."
+	name = "\improper Bluespace Technician's Glasses"
+	desc = "A pair of modified sunglasses. The word 'BST' is stamped on the side."
 //	var/list/obj/item/clothing/glasses/hud/health/hud = null
 	vision_flags = (SEE_TURFS|SEE_OBJS|SEE_MOBS)
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
@@ -413,65 +432,64 @@
 		src.hud += new/obj/item/clothing/glasses/hud/health(src)
 		return
 */
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the [src]. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/clothing/glasses/sunglasses/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
 
 //Shoes
 /obj/item/clothing/shoes/black/bst
-	name = "Bluespace Technician's shoes"
-	name = "Bluespace Technician's shoes, 'BST' marked on the side."
+	name = "\improper Bluespace Technician's shoes"
+	desc = "A pair of black shoes with extra grip. The letters 'BST' are stamped on the side."
 	icon_state = "black"
-	desc = "A pair of black shoes. 'BST' marked on the side."
 	flags = NOSLIP
 	canremove = 0
 
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the [src]. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/clothing/shoes/black/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
 
-		return 1 //Because Bluespace
+	return 1 //Because Bluespace
 
 //ID
 /obj/item/weapon/card/id/bst
 	icon_state = "centcom"
-	desc = "An ID straight from Cent. Com, this one looks highly classified"
+	desc = "An ID straight from Central Command. This one looks highly classified."
 //	canremove = 0
 	New()
 		access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
 
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the [src] ID. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/weapon/card/id/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
 
 /obj/item/device/pda/captain/bst
 	hidden = 1
 	message_silent = 1
 //	ttone = "DO SOMETHING HERE"
 
-	attack_hand()
-		if(!usr)
-			return
-		if(!istype(usr, /mob/living/carbon/human/bst))
-			usr << "<span class='alert'>Your hand seems to go right through the pda. It's like it doesn't exist.</span>"
-			return
-		else
-			..()
+/obj/item/device/pda/captain/bst/attack_hand()
+	if(!usr)
+		return
+	if(!istype(usr, /mob/living/carbon/human/bst))
+		usr << span("alert", "Your hand seems to go right through the [src]. It's like it doesn't exist.")
+		return
+	else
+		..()
 
 /mob/living/carbon/human/bst/restrained()
 	return 0

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -201,6 +201,7 @@
 		return
 	explosion(get_turf(src), explosion_values[1], explosion_values[2], explosion_values[3], explosion_values[4])
 	if(holder && holder.wearer)
+		holder.wearer.gib()
 		holder.wearer.drop_from_inventory(src)
 		qdel(holder)
 	qdel(src)

--- a/code/modules/mob/language/generic.dm
+++ b/code/modules/mob/language/generic.dm
@@ -20,7 +20,7 @@
 
 // 'basic' language; spoken by default.
 /datum/language/common
-	name = "Ceti Basic"
+	name = LANGUAGE_TCB
 	desc = "The common galactic tongue."
 	speech_verb = "says"
 	whisper_verb = "whispers"
@@ -39,7 +39,7 @@
 
 // Galactic common languages (systemwide accepted standards).
 /datum/language/trader
-	name = "Tradeband"
+	name = LANGUAGE_TRADEBAND
 	desc = "Maintained by the various trading cartels in major systems, this elegant, structured language is used for bartering and bargaining."
 	speech_verb = "enunciates"
 	colour = "say_quote"
@@ -56,7 +56,7 @@
 
 // Criminal language.
 /datum/language/gutter
-	name = "Gutter"
+	name = LANGUAGE_GUTTER
 	desc = "Much like Standard, this crude pidgin tongue descended from numerous languages and serves as Tradeband for criminal elements."
 	speech_verb = "growls"
 	colour = "rough"
@@ -65,7 +65,7 @@
 
 // Sign language
 /datum/language/sign
-	name = "Sign Language"
+	name = LANGUAGE_SIGN
 	desc = "A signed version of Standard, though its intent is primarily to help out people who are deaf and mute, "
 	speech_verb = "signs"
 	signlang_verb = list("signs", "gestures")

--- a/code/modules/mob/language/monkey.dm
+++ b/code/modules/mob/language/monkey.dm
@@ -1,5 +1,5 @@
 /datum/language/human/monkey
-	name = "Chimpanzee"
+	name = LANGUAGE_CHIMPANZEE
 	desc = "Ook ook ook."
 	speech_verb = "chimpers"
 	ask_verb = "chimpers"
@@ -7,22 +7,22 @@
 	key = "6"
 
 /datum/language/skrell/monkey
-	name = "Neaera"
+	name = LANGUAGE_NEAERA
 	desc = "Squik squik squik."
 	key = "8"
 
 /datum/language/unathi/monkey
-	name = "Stok"
+	name = LANGUAGE_STOK
 	desc = "Hiss hiss hiss."
 	key = "7"
 
 /datum/language/tajaran/monkey
-	name = "Farwa"
+	name = LANGUAGE_FARWA
 	desc = "Meow meow meow."
 	key = "^"
 
 /datum/language/bug/monkey
-	name = "V'krexi"
+	name = LANGUAGE_BUG
 	desc = "Buzz buzz buzz."
 	key = "#"
 	speech_verb = "chitters"

--- a/code/modules/mob/language/outsider.dm
+++ b/code/modules/mob/language/outsider.dm
@@ -1,5 +1,5 @@
 /datum/language/xenocommon
-	name = "Xenomorph"
+	name = LANGUAGE_XENOMORPH
 	colour = "alien"
 	desc = "The common tongue of the xenomorphs."
 	speech_verb = "hisses"
@@ -10,7 +10,7 @@
 	syllables = list("sss","sSs","SSS")
 
 /datum/language/xenos
-	name = "Hivemind"
+	name = LANGUAGE_HIVEMIND
 	desc = "Xenomorphs have the strange ability to commune over a psychic hivemind."
 	speech_verb = "hisses"
 	ask_verb = "hisses"
@@ -30,7 +30,7 @@
 	return 0
 
 /datum/language/ling
-	name = "Changeling"
+	name = LANGUAGE_CHANGELING
 	desc = "Although they are normally wary and suspicious of each other, changelings can commune over a distance."
 	speech_verb = "says"
 	colour = "changeling"
@@ -45,7 +45,7 @@
 		..(speaker,message)
 
 /datum/language/corticalborer
-	name = "Cortical Link"
+	name = LANGUAGE_BORER
 	desc = "Cortical borers possess a strange link between their tiny minds."
 	speech_verb = "sings"
 	ask_verb = "sings"
@@ -69,7 +69,7 @@
 	..(speaker,message,speaker_mask)
 
 /datum/language/vox
-	name = "Vox-pidgin"
+	name = LANGUAGE_VOX
 	desc = "The common tongue of the various Vox ships making up the Shoal. It sounds like chaotic shrieking to everyone else."
 	speech_verb = "shrieks"
 	ask_verb = "creels"
@@ -84,7 +84,7 @@
 	return ..(FEMALE,1,6)
 
 /datum/language/cultcommon
-	name = "Cult"
+	name = LANGUAGE_CULT
 	desc = "The chants of the occult, the incomprehensible."
 	speech_verb = "intones"
 	ask_verb = "intones"
@@ -108,7 +108,7 @@
 	return new_name
 
 /datum/language/cult
-	name = "Occult"
+	name = LANGUAGE_OCCULT
 	desc = "The initiated can share their thoughts by means defying all reason."
 	speech_verb = "intones"
 	ask_verb = "intones"
@@ -118,7 +118,7 @@
 	flags = RESTRICTED | HIVEMIND
 
 /datum/language/terminator
-	name = "Hephaestus Darkcomms"
+	name = LANGUAGE_TERMINATOR
 	desc = "A heavily encrypted communication network that piggybacks off of the state telecomms relays to covertly link Hephaestus black ops droids to their control AIs."
 	speech_verb = "buzzes"
 	ask_verb = "buzzes"

--- a/code/modules/mob/language/synthetic.dm
+++ b/code/modules/mob/language/synthetic.dm
@@ -1,5 +1,5 @@
 /datum/language/binary
-	name = "Robot Talk"
+	name = LANGUAGE_ROBOT
 	desc = "Most human stations support free-use communications protocols and routing hubs for synthetic use."
 	colour = "say_quote"
 	speech_verb = "states"
@@ -52,7 +52,7 @@
 		R.cell_use_power(C.active_usage)
 
 /datum/language/binary/drone
-	name = "Drone Talk"
+	name = LANGUAGE_DRONE
 	desc = "A heavily encoded damage control coordination stream."
 	speech_verb = "transmits"
 	ask_verb = "transmits"

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -47,13 +47,20 @@
 	autohiss_extra_map = list(
 			"x" = list("ks", "kss", "ksss")
 		)
-	autohiss_exempt = list(LANGUAGE_UNATHI)
+	autohiss_exempt = list(
+			LANGUAGE_UNATHI,
+			LANGUAGE_AZAZIBA
+		)
 
 /datum/species/tajaran
 	autohiss_basic_map = list(
 			"r" = list("rr", "rrr", "rrrr")
 		)
-	autohiss_exempt = list(LANGUAGE_SIIK_TAJR)
+	autohiss_exempt = list(
+			LANGUAGE_SIIK_MAAS,
+			LANGUAGE_SIIK_TAJR,
+			LANGUAGE_SIGN_TAJARA
+		)
 
 /datum/species/bug
 	autohiss_basic_map = list(
@@ -80,6 +87,9 @@
 	if(!autohiss_basic_map)
 		return message
 	if(autohiss_exempt && (lang.name in autohiss_exempt))
+		return message
+	// No reason to auto-hiss in sign-language.
+	if (lang.flags && (lang.flags & SIGNLANG))
 		return message
 
 	var/map = autohiss_basic_map.Copy()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -112,8 +112,6 @@
 		msg += "<span class='warning'>[T.He] [T.has] [(hand_blood_color != "#030303") ? "blood" : "oil"]-stained hands!</span>\n"
 
 	//handcuffed?
-
-	//handcuffed?
 	if(handcuffed)
 		if(istype(handcuffed, /obj/item/weapon/handcuffs/cable))
 			msg += "<span class='warning'>[T.He] [T.is] \icon[handcuffed] restrained with cable!</span>\n"
@@ -197,7 +195,7 @@
 	var/distance = get_dist(usr,src)
 	if(istype(usr, /mob/dead/observer) || usr.stat == 2) // ghosts can see anything
 		distance = 1
-	if (src.stat)
+	if (src.stat && !(src.species.flags & NO_BLOOD))	// No point checking pulse of a species that doesn't have one.
 		msg += "<span class='warning'>[T.He] [T.is]n't responding to anything around [T.him] and seems to be asleep.</span>\n"
 		if((stat == 2 || src.losebreath) && distance <= 3)
 			msg += "<span class='warning'>[T.He] [T.does] not appear to be breathing.</span>\n"
@@ -210,13 +208,16 @@
 				else
 					usr << "<span class='deadsay'>[T.He] [T.has] a pulse!</span>"
 
+	else if (src.stat)
+		msg += span("warning", "[T.He] [T.is] not responding to anything around [T.him].\n")
+
 	if(fire_stacks)
 		msg += "[T.He] [T.is] covered in some liquid.\n"
 	if(on_fire)
-		msg += "<span class='warning'>[T.He] [T.is] on fire!.</span>\n"
+		msg += "<span class='danger'>[T.He] [T.is] on fire!</span>\n"
 	msg += "<span class='warning'>"
 
-	/*
+	
 	if(nutrition < 100)
 		msg += "[T.He] [T.is] severely malnourished.\n"
 	else if(nutrition >= 500)
@@ -224,7 +225,7 @@
 			msg += "[T.He] [T.is] plump and delicious looking - Like a fat little piggy. A tasty piggy.\n"
 		else*/
 		msg += "[T.He] [T.is] quite chubby.\n"
-	*/
+	
 
 	msg += "</span>"
 
@@ -257,7 +258,8 @@
 		if(temp)
 			if(temp.status & ORGAN_ROBOT)
 				if(!(temp.brute_dam + temp.burn_dam))
-					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]!</span>\n"
+					//wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]!</span>\n"
+					// No need to notify about robotic limbs if they're not damaged, really.
 					continue
 				else
 					wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] a robot [temp.name]. It has[temp.get_wounds_desc()]!</span>\n"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1092,6 +1092,11 @@
 
 	if(usr == src)
 		self = 1
+
+	if (src.species.flags & NO_BLOOD)
+		usr << span("notice", self ? "Your species does not have a pulse." : "[src]'s species does not have a pulse.")
+		return
+
 	if(!self)
 		usr.visible_message("<span class='notice'>[usr] kneels down, puts \his hand on [src]'s wrist and begins counting their pulse.</span>",\
 		"You begin counting [src]'s pulse")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -189,6 +189,15 @@ proc/get_radio_key_from_channel(var/channel)
 
 	if(!message || message == "")
 		return 0
+	
+	//handle nonverbal and sign languages here
+	if (speaking)
+		if (speaking.flags & NONVERBAL)
+			if (prob(30))
+				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
+
+		if (speaking.flags & SIGNLANG)
+			return say_signlang(message, pick(speaking.signlang_verb), speaking)
 
 	var/list/obj/item/used_radios = new
 	if(handle_message_mode(message_mode, message, verb, speaking, used_radios, alt_name))
@@ -217,15 +226,6 @@ proc/get_radio_key_from_channel(var/channel)
 				sound_vol *= 0.5
 
 	var/turf/T = get_turf(src)
-
-	//handle nonverbal and sign languages here
-	if (speaking)
-		if (speaking.flags & NONVERBAL)
-			if (prob(30))
-				src.custom_emote(1, "[pick(speaking.signlang_verb)].")
-
-		if (speaking.flags & SIGNLANG)
-			return say_signlang(message, pick(speaking.signlang_verb), speaking)
 
 	var/list/listening = list()
 	var/list/listening_obj = list()

--- a/code/modules/projectiles/guns/energy/lawgiver.dm
+++ b/code/modules/projectiles/guns/energy/lawgiver.dm
@@ -117,6 +117,9 @@
 		..()
 
 /obj/item/weapon/gun/energy/lawgiver/hear_talk(mob/living/M in range(0,src), msg)
+	var/mob/living/carbon/human/H = M
+	if (!H)
+		return
 	if( (src.dna==usr.dna.unique_enzymes || emagged) && (src in usr.contents))
 		hear(msg)
 	return

--- a/html/changelogs/lohikar-fixes3.yml
+++ b/html/changelogs/lohikar-fixes3.yml
@@ -1,0 +1,12 @@
+author: Lohikar
+delete-after: True
+changes: 
+  - tweak: "Auto-Hiss should no longer act on sign languages."
+  - tweak: "Auto-Hiss should no longer act on Tajaran languages."
+  - tweak: "Auto-Hiss should no longer act on Unathi languages."
+  - tweak: "Examining an IPC no longer checks their non-existent pulse."
+  - tweak: "You can no longer check the pulse of a species that does not have one."
+  - bugfix: "Examining a human-type mob with robotic limbs no longer shows red examine text for each limb."
+  - bugfix: "Examining a human-type mob now shows hunger level again."
+  - bugfix: "The Ninja's self-destruct should actually kill the Ninja now."
+  - bugfix: "You can no longer use sign language over radios."


### PR DESCRIPTION
changes:

tweak: "Auto-Hiss should no longer act on sign languages."
tweak: "Auto-Hiss should no longer act on Tajaran languages."
tweak: "Auto-Hiss should no longer act on Unathi languages."
tweak: "Examining an IPC no longer checks their non-existent pulse."
tweak: "You can no longer check the pulse of a species that does not have one."
bugfix: "Examining a human-type mob with robotic limbs no longer shows red examine text for each limb."
bugfix: "Examining a human-type mob now shows hunger level again."
bugfix: "The Ninja's self-destruct should actually kill the Ninja now."
bugfix: "You can no longer use sign language over radios."
Changes not in changelog:

Cleaned up the BST's code a bit.
BSTs now understand/speak the newly added languages
Added #define for languages that did not have them.
BSTs now understand/speak Vaurca Hivenet.
Slightly tweaked names/descriptions of BST items.
Fixed runtime from lawgivers overhearing speech from non-human mobs.
Fixes #1492
Fixes #1500
Fixes #1505

* Please describe the intent of your changes in a clear fashion.
* Please make sure that, in the case of icon or mapping changes, you include images of these changes in the PR's description.
